### PR TITLE
Exchange assets post update

### DIFF
--- a/spec/exchange_assets.yml
+++ b/spec/exchange_assets.yml
@@ -653,8 +653,6 @@ components:
         - version
         - name
         - classifier
-        - apiVersion
-        - main
         - groupId
         - asset
       type: object
@@ -679,6 +677,7 @@ components:
         classifier:
           type: string
           enum:
+            - mule-application
             - raml-fragment
             - raml
             - oas


### PR DESCRIPTION
The exchange_assets post method incorrectly requires apiVersion and main - which are not required for all classifier types i.e. `mule-application` which I have added to the list of classifier enums

See Anypoint CLI example
https://help.salesforce.com/s/articleView?id=001119648&type=1

https://docs.mulesoft.com/anypoint-cli/latest/exchange-assets#exchange-asset-upload