### PR TITLE
Exchange assets

### DIFF
--- a/spec/application_manager_v2.yml
+++ b/spec/application_manager_v2.yml
@@ -472,7 +472,6 @@ components:
           type: object
         vCores:
           type: number
-          format: float
           description: The application allocated virtual cores.
         integrations:
           type: object


### PR DESCRIPTION
The exchange_assets post method incorrectly requires apiVersion and main - which are not required for all classifier types i.e. mule-application which I have added to the list of classifier enums

See Anypoint CLI example
https://help.salesforce.com/s/articleView?id=001119648&type=1

https://docs.mulesoft.com/anypoint-cli/latest/exchange-assets#exchange-asset-upload