### PR TITLE
Update postAssetResponse to properly handle metadata.tags as an array…

### DIFF
--- a/spec/exchange_assets.yml
+++ b/spec/exchange_assets.yml
@@ -788,7 +788,14 @@ components:
               type: array
               title: tags
               items:
-                type: string
+                type: object
+                properties:
+                  key:
+                    type: string
+                    title: key
+                  value:
+                    type: string
+                    title: value
             name:
               type: string
               title: name


### PR DESCRIPTION
When attempting to publish something with tags the response object needs to parse a json array of tags containing key value fields
Sample response with metadata... the current response expects string, which results in an error:
`ERRO[2024-10-30T09:54:49-07:00] json: cannot unmarshal object into Go struct field Metadata.metadata.tags of type string`

```
{
  "metadata": {
    "classifier": "raml",
    "tags": [
      {
        "value": "raml"
      },
      {
        "value": "rest"
      },
      {
        "value": "api"
      },
      {
        "key": "product-api-version",
        "value": "v1"
      },
      {
        "key": "original-format",
        "value": "raml"
      }
    ]
  }
}
```