### PR TITLE
Update isCloudHub to be a boolean

### DIFF
--- a/spec/apim.yml
+++ b/spec/apim.yml
@@ -679,7 +679,7 @@ components:
           type: string
           nullable: true
         isCloudHub:
-          type: string
+          type: boolean
           nullable: true
         deploymentType:
           type: string
@@ -741,7 +741,7 @@ components:
         type:
           type: string
         isCloudHub:
-          type: string
+          type: boolean
           nullable: true
         proxyUri:
           type: string


### PR DESCRIPTION
Calling `GetApimInstanceDetails` results in an error due to isCloudHub being handled as a string, should be a boolean

```
GetApi: json: cannot unmarshal bool into Go struct field Endpoint.endpoint.isCloudHub of type string
error getting api: json: cannot unmarshal bool into Go struct field Endpoint.endpoint.isCloudHub of type string
```