### PR TITLE
Change endpoint.console type from string to object

### DIFF
--- a/spec/apim.yml
+++ b/spec/apim.yml
@@ -704,8 +704,7 @@ components:
           type: string
           nullable: true
         console:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/Console'
         tlsContexts:
           type: object
           properties:
@@ -834,6 +833,16 @@ components:
           type: string
         apiId:
           type: integer
+
+    Console:
+      title: Console
+      type: object
+      nullable: true
+      properties:
+        enabled:
+          type: boolean
+        path:
+          type: string
 
     DeploymentPostBody:
       title: DeploymentPostBody


### PR DESCRIPTION
terraform-provider-anypoint fails to apply this configuration with the following error 

```
resource "anypoint_apim_mule4" "api" {
  org_id                   = var.org_id
  env_id                   = var.env_id
  asset_group_id           = var.group_id
  asset_id                 = var.asset_id
  asset_version            = var.asset_version
  endpoint_uri             = var.endpoint_uri
  endpoint_deployment_type = "HY"
  endpoint_proxy_uri       = "http://0.0.0.0:8081/"
}
```
```anypoint-client-go: json: cannot unmarshal object into Go struct field Endpoint.endpoint.console of type string```

When curling the same request from the [api manager endpoint](https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/api-manager-api/minor/1.0/console/method/%23571/), `console` is returned as an object with two fields and not a string:

```json
"endpoint": {
    "deploymentType": "HY",
    "isCloudHub": null,
    "muleVersion4OrAbove": true,
    "proxyRegistrationUri": null,
    "proxyUri": "http://0.0.0.0:8081/",
    "tlsContexts": null,
    "console": {
        "enabled": true,
        "path": "/console/*"
    },
}
```