### PR TITLE
[Fix] APIM: updates apim Policy Full Response schema

### DIFF
--- a/spec/apim.yml
+++ b/spec/apim.yml
@@ -704,8 +704,7 @@ components:
           type: string
           nullable: true
         console:
-          type: string
-          nullable: true
+          $ref: '#/components/schemas/Console'
         tlsContexts:
           type: object
           properties:
@@ -834,6 +833,16 @@ components:
           type: string
         apiId:
           type: integer
+
+    Console:
+      title: Console
+      type: object
+      nullable: true
+      properties:
+        enabled:
+          type: boolean
+        path:
+          type: string
 
     DeploymentPostBody:
       title: DeploymentPostBody

--- a/spec/apim_policy.yml
+++ b/spec/apim_policy.yml
@@ -651,16 +651,44 @@ components:
     ApimPolicyCollection:
       oneOf:
         - type: array
-          title: "ApimPolicyCollecion"
+          title: "ApimPolicyCollection"
           items:
             $ref: "#/components/schemas/ApimPolicy"
-        - type: object
-          title: "ApimPolicyFullCollecion"
+        - $ref: "#/components/schemas/ApimPolicyFullData"
+
+    ApimPolicyFullData:
+      type: object
+      title: "ApimPolicyFullData"
+      properties:
+        policies:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApimPolicyFull"
+        tiers:
+          type: object
           properties:
-            policies:
+            values:
               type: array
               items:
-                $ref: "#/components/schemas/ApimPolicyFull"
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  limits:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        maximumRequests:
+                          type: integer
+                        timePeriodInMilliseconds:
+                          type: integer
+                          format: int64
+                        visible:
+                          type: boolean
+            version:
+              type: integer
+              format: int64
 
     ApimPolicy:
       type: object


### PR DESCRIPTION
updates apim Policy Full Data response schema to iclude tiers property.

Fixes issue in go where: data failed to match schemas in oneOf(ApimPolicyCollection)