### PR TITLE
fix(team-roles): correct GET response status code 201 -> 200

### DIFF
--- a/spec/team_roles.yaml
+++ b/spec/team_roles.yaml
@@ -64,7 +64,7 @@ paths:
           $ref: '#/components/responses/BadRequestError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '201':    # status code
+        '200':
           $ref: '#/components/responses/SuccessListTeamRoles'
     post:
       operationId: assignTeamRoles
@@ -77,7 +77,7 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '201':    # status code
+        '201':
           $ref: '#/components/responses/SuccessPostTeamRoles'
     delete:
       operationId: deleteTeamRoles


### PR DESCRIPTION
GetTeamRoles is a list endpoint and returns 200 OK, not 201. The spec declared the success response under '201' which produced an incorrect generated client (200 responses were treated as unknown, breaking deserialization on the happy path).

Also drops a dangling '# status code' inline comment from the POST response key for consistency.

Proposed module version after merge: team_roles/v<MINOR+1> (bug fix on a generated response; treat as fix bump unless downstream relied on the 201 path).