### PR TITLE
release: private-space TGW endpoints + team-roles fix + agent rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+  Thanks for contributing to anypoint-automation-client-generator.
+  Each PR drives generated Go client modules in github.com/mulesoft-anypoint/anypoint-client-go.
+  Be precise: a careless spec change ripples downstream into every Terraform / SDK consumer.
+-->
+
+## Summary
+
+<!-- 1–3 bullets. What does this PR change? -->
+
+-
+-
+
+## Affected modules
+
+<!-- List every spec/<service>.yml touched. The CI pipeline regenerates these modules on master-merge. -->
+
+- `spec/<service>.yml` →  `anypoint-client-go/<service>`
+
+## Related
+
+- Provider issue / PR: <link to terraform-provider-anypoint>
+- Anypoint API docs (if any): <link>
+- HAR evidence (if API surface was reverse-engineered): <path / commit in `recordings/`>
+
+## Type of change
+
+- [ ] New endpoint(s) on existing service
+- [ ] New service (whole new spec file)
+- [ ] Bug fix in existing schema / response
+- [ ] Breaking change (renamed field, removed endpoint, changed required-ness)
+- [ ] Generator config / tooling
+
+## Spec checklist (OAS3 conventions)
+
+- [ ] OAS 3.0.0.
+- [ ] All schemas live in `#/components/schemas`; paths reference via `$ref`.
+- [ ] Every schema and every attribute has a **`title`** (camelCase, unique across the spec).
+- [ ] No `oneOf` / `anyOf` in response bodies — generator can't infer a Go type.
+- [ ] `operationId` set on every operation, verb-prefixed, stable. Generated Go method name = this.
+- [ ] Standard error responses (`401`, `403`, `404`, `400`) `$ref` shared response components instead of inlining.
+- [ ] Raw-string body responses declared as `schema: { type: string }`.
+- [ ] No unnecessary `required` fields.
+- [ ] `npx openapi-generator-cli validate -i spec/<service>.yml` is clean.
+
+## Local generation
+
+- [ ] `make generate` (or `npx openapi-generator-cli generate`) succeeds with no warnings on this branch.
+- [ ] Local consumer test: ran `go mod edit -replace …=./dest/<service>` in a downstream project and `go build` passes.
+
+## Breaking change notice
+
+<!-- If any 'Breaking change' box above is ticked, explain here. Include migration steps for downstream consumers. -->
+
+## Release plan
+
+- [ ] On merge to `master`, pipeline regenerates `anypoint-client-go/<service>`.
+- [ ] After pipeline publishes, the affected module(s) need to be tagged. Proposed version: `<service>/vX.Y.Z` (semver bump rationale: …).
+- [ ] Downstream provider/SDK consumers will switch from `replace` → released tag once the tag is up.
+
+## Notes for reviewer
+
+<!-- API quirks, undocumented behavior, response shape oddities (truncated/array-wrapped), etc. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+# AGENTS.md
+
+Agent rules for `anypoint-automation-client-generator`. Read by Claude Code, Roo Code, Cursor, and any tool supporting the `AGENTS.md` convention.
+
+## Project context
+
+- This repo owns the OpenAPI 3.0.0 specs that drive every `github.com/mulesoft-anypoint/anypoint-client-go/<service>` module.
+- Specs live in `spec/<service>.yml`. One file per Anypoint API (private_space, vpc, dlb, env, org, etc.).
+- The CLI tool is `openapi-generator-cli` (Node, configured via `openapitools.json`).
+- Downstream: `terraform-provider-anypoint` and any other Anypoint SDK consumer.
+
+## Big picture
+
+```
+spec/<service>.yml  ──(openapi-generator-cli)──▶  dest/<service>/    (local, gitignored)
+       │                                                  │
+       │ PR merged to master                              │ go mod replace (during dev)
+       ▼                                                  ▼
+       CI generates + pushes ──▶ github.com/mulesoft-anypoint/anypoint-client-go/<service>
+                                                ▲
+                                                │ user tags the module
+                                                │
+                                  Downstream `go get @vX.Y.Z`
+```
+
+## Generator workflow
+
+```bash
+# 1. install once
+npm install
+
+# 2. point generator at a writable destination
+export ANYPOINT_GENERATOR_GO_DEST=`pwd`/dest
+
+# 3. generate everything
+npx openapi-generator-cli generate
+
+# Or just one service
+make generate     # if Makefile target exists
+```
+
+Validate a single spec before generating:
+
+```bash
+npx openapi-generator-cli validate -i spec/<service>.yml
+```
+
+## Spec authoring rules
+
+Inherited from README.md, with extra detail:
+
+### Mandatory
+
+- **OAS 3.0.0.** No 3.1 features.
+- **All schemas in `#/components/schemas`**, referenced from paths via `$ref`. Don't inline body schemas in operations.
+- **Every schema + every attribute has a `title`** in camelCase. The `title` becomes the Go struct / field name. Inconsistent titles produce ugly Go.
+- **`title` must be unique across the spec.** Two different schemas titled `Spec` collide.
+- **`operationId` on every operation.** It becomes the Go method name. Prefix with the verb (`Create…`, `Get…`, `Update…`, `Delete…`, `List…`). Keep stable — renaming breaks every consumer.
+
+### Forbidden
+
+- `oneOf` / `anyOf` in response bodies. The generator can't infer a Go type. If the field genuinely supports multiple types, leave the type empty and document with `description` only.
+- `$ref` to a primitive type (string / int / bool). Use the type inline.
+- Unnecessary `required` fields. Mark `required` only when the API truly rejects a missing field.
+
+### Patterns for common shapes
+
+- **Raw-string response body** (e.g. an account id endpoint returning `"904814986745"`):
+  ```yaml
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: string
+  ```
+- **Array-wrapped single resource** (some Anypoint endpoints wrap a singleton in `[]`):
+  ```yaml
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TransitGateway'
+  ```
+- **Truncated response** vs the canonical schema: declare a separate `…Result` schema. Don't lie about which fields the API actually returns.
+
+### Shared error responses
+
+Reuse `#/components/responses/UnauthorizedError`, `ForbiddenError`, `BadRequestError`, `NotFoundError` instead of inlining `401`/`403`/`404` per operation. Add new shared response components there if missing.
+
+### DELETE with body
+
+OAS-purist editors complain; the generator supports it. Add `requestBody` anyway when the API requires it. Ignore the editor warning.
+
+## Naming conventions
+
+| Element | Convention | Example |
+|---|---|---|
+| Spec filename | `<service>.yml`, snake_case | `private_space.yml` |
+| Schema title | PascalCase, unique | `TransitGateway`, `TransitGatewayPostBody` |
+| Attribute title | camelCase | `resourceShareId`, `accountId` |
+| operationId | `<Verb><Noun>` PascalCase | `CreatePrivateSpaceTransitGateway`, `GetOrgTransitGateways` |
+| Path variable | camelCase | `{orgId}`, `{psId}`, `{tgwId}` |
+
+## Branching & release
+
+- Feature branches target `dev`.
+- After PR review, `dev` merges to `master`.
+- On `master` merge, CI generates client modules and pushes them to the `anypoint-client-go` org repository.
+- **Tagging** of individual `<service>/vX.Y.Z` modules is a manual step performed by a maintainer (typically after a downstream consumer confirms the new shape compiles).
+- Always specify `Proposed version: <service>/vX.Y.Z` in the PR description so the maintainer has a default to use.
+
+## Workflow when working with a downstream consumer
+
+Typical loop (e.g. provider asks for a new endpoint):
+
+1. Capture API surface (HAR / docs / direct curl).
+2. Edit `spec/<service>.yml`, validate.
+3. Local regen (`make generate` or `npx openapi-generator-cli generate`).
+4. Downstream switches via `go mod edit -replace …=./dest/<service>`. Iterate until happy.
+5. Open PR here (use `.github/PULL_REQUEST_TEMPLATE.md`).
+6. Merge → CI publishes generated module.
+7. Maintainer tags `<service>/vX.Y.Z`.
+8. Downstream switches back: `go mod edit -dropreplace …` + `go get @vX.Y.Z`.
+
+## Avoid
+
+- Committing anything under `dest/` (it's gitignored — keep it that way).
+- Committing `node_modules/`.
+- Hand-edits to generated Go in the downstream repo — fix the spec instead.
+- Renaming an `operationId` or a schema `title` casually: this is a breaking change. Bump major when you do.
+- Using `oneOf` / `anyOf` to "be flexible" — leaves Go callers with unusable types.
+
+## Reference
+
+- OpenAPI Generator: <https://openapi-generator.tech/>
+- OpenAPI inheritance/polymorphism: <https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/>
+- Consumer convention: `../terraform-provider-anypoint/AGENTS.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/spec/private_space.yml
+++ b/spec/private_space.yml
@@ -171,6 +171,224 @@ paths:
         '200':    # status code
           $ref: '#/components/responses/SuccessGetPrivateSpaceIamRoles'
 
+  /organizations/{orgId}/privatespaces/{privateSpaceId}/transitgateways:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+      - name: privateSpaceId
+        in: path
+        description: The ID of the private space in GUID format
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPrivateSpaceTransitGateways
+      description: lists transit gateway attachments for the given private space
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':
+          $ref: '#/components/responses/SuccessListTransitGateways'
+    post:
+      operationId: createPrivateSpaceTransitGateway
+      description: creates a transit gateway attachment on the given private space
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitGatewayPostBody'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '201':
+          $ref: '#/components/responses/SuccessCreateTransitGateway'
+
+  /organizations/{orgId}/privatespaces/{privateSpaceId}/transitgateways/{transitGatewayId}:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+      - name: privateSpaceId
+        in: path
+        description: The ID of the private space in GUID format
+        required: true
+        schema:
+          type: string
+      - name: transitGatewayId
+        in: path
+        description: The transit gateway id (AWS tgw-...).
+        required: true
+        schema:
+          type: string
+    patch:
+      operationId: updatePrivateSpaceTransitGatewayRoutes
+      description: updates the static routes of a transit gateway attachment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitGatewayPatchRoutesBody'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':
+          $ref: '#/components/responses/SuccessUpdateTransitGatewayRoutes'
+    delete:
+      operationId: deletePrivateSpaceTransitGateway
+      description: deletes a transit gateway attachment from the given private space
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '204':
+          description: Transit gateway attachment deleted
+
+  /organizations/{orgId}/transitgateways:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getOrgTransitGateways
+      description: lists transit gateways across the organization, optionally filtered by region and private space id
+      parameters:
+        - name: region
+          in: query
+          description: AWS region filter.
+          required: false
+          schema:
+            type: string
+        - name: privateSpaceId
+          in: query
+          description: Private space id filter (GUID).
+          required: false
+          schema:
+            type: string
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '200':
+          $ref: '#/components/responses/SuccessListTransitGateways'
+
+  /organizations/{orgId}/transitgateways/{transitGatewayId}:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+      - name: transitGatewayId
+        in: path
+        description: The transit gateway id (AWS tgw-...).
+        required: true
+        schema:
+          type: string
+    patch:
+      operationId: updateOrgTransitGatewayName
+      description: updates the name of a transit gateway
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitGatewayPatchNameBody'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':
+          $ref: '#/components/responses/SuccessUpdateTransitGatewayName'
+
+  /organizations/{orgId}/privatespaces/{privateSpaceId}/accounts:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+      - name: privateSpaceId
+        in: path
+        description: The ID of the private space in GUID format
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPrivateSpaceMulesoftAccount
+      description: returns the MuleSoft AWS account id (region-bound to the private space) to whitelist as RAM share principal
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':
+          $ref: '#/components/responses/SuccessGetPrivateSpaceMulesoftAccount'
+
+  /organizations/{orgId}/privatespaces/{privateSpaceId}/routes:
+    parameters:
+      - name: orgId
+        in: path
+        description: The ID of the organization in GUID format
+        required: true
+        schema:
+          type: string
+      - name: privateSpaceId
+        in: path
+        description: The ID of the private space in GUID format
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPrivateSpaceRoutes
+      description: lists static routes for the private space network
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':
+          $ref: '#/components/responses/SuccessListPrivateSpaceRoutes'
+
 components:
   securitySchemes:
     bearerAuth:            # arbitrary name for the security scheme
@@ -225,6 +443,50 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/PrivateSpaceIamRoles'
+    SuccessListTransitGateways:
+      description: List of transit gateways
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TransitGateway'
+    SuccessCreateTransitGateway:
+      description: Transit gateway attachment created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TransitGateway'
+    SuccessUpdateTransitGatewayRoutes:
+      description: Transit gateway routes updated (truncated array wrap)
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TransitGatewayPatchRoutesResult'
+    SuccessUpdateTransitGatewayName:
+      description: Transit gateway name updated (full array wrap)
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/TransitGateway'
+    SuccessGetPrivateSpaceMulesoftAccount:
+      description: MuleSoft AWS account id, region-bound (raw string body)
+      content:
+        application/json:
+          schema:
+            type: string
+    SuccessListPrivateSpaceRoutes:
+      description: Private space route table
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/PrivateSpaceRoute'
 
   schemas:
     PrivateSpaceSummary:
@@ -662,3 +924,130 @@ components:
           type: integer
           format: int64
           description: Last known timestamp of the status in EPOCH.
+
+    TransitGateway:
+      title: TransitGateway
+      type: object
+      properties:
+        id:
+          type: string
+          description: AWS transit gateway id (e.g. tgw-017e20b9ce00c865c).
+        name:
+          type: string
+          description: User-chosen display name for the attachment.
+        accountId:
+          type: string
+          description: MuleSoft AWS account id (region-bound to the private space).
+        spec:
+          type: object
+          properties:
+            resourceShare:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: RAM resource share UUID (trailing GUID of the ARN).
+                account:
+                  type: string
+                  description: AWS account id that owns the RAM share.
+            region:
+              type: string
+              description: AWS region (inherits the private space region).
+            spaceName:
+              type: string
+              description: Private space display name.
+        status:
+          type: object
+          properties:
+            gateway:
+              type: string
+              description: Gateway status (e.g. refreshing, available).
+            attachment:
+              type: string
+              description: Attachment status (e.g. refreshing, available).
+            tgwResource:
+              type: string
+              description: AWS console URL pointing at the transit gateway resource.
+            routes:
+              type: array
+              description: Static routes pushed into the private space route table.
+              items:
+                type: string
+
+    TransitGatewayPostBody:
+      title: TransitGatewayPostBody
+      type: object
+      required:
+        - name
+        - resourceShareId
+        - resourceShareAccount
+        - routes
+      properties:
+        name:
+          type: string
+          description: Display name for the transit gateway attachment.
+        resourceShareId:
+          type: string
+          description: RAM resource share UUID (trailing GUID of the ARN, NOT the full ARN).
+        resourceShareAccount:
+          type: string
+          description: AWS account id that owns the RAM share (your AWS account, NOT MuleSoft's account).
+        routes:
+          type: array
+          description: Static routes (CIDR strings) to push into the private space route table. Must not equal or be more specific than the private space CIDR.
+          items:
+            type: string
+
+    TransitGatewayPatchRoutesBody:
+      title: TransitGatewayPatchRoutesBody
+      type: object
+      required:
+        - routes
+      properties:
+        routes:
+          type: array
+          description: Replacement set of static routes (CIDR strings).
+          items:
+            type: string
+
+    TransitGatewayPatchNameBody:
+      title: TransitGatewayPatchNameBody
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: New display name.
+
+    TransitGatewayPatchRoutesResult:
+      title: TransitGatewayPatchRoutesResult
+      description: Truncated transit gateway shape returned by the routes PATCH endpoint.
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        deploymentId:
+          type: string
+        resourceShareId:
+          type: string
+        routes:
+          type: array
+          items:
+            type: string
+
+    PrivateSpaceRoute:
+      title: PrivateSpaceRoute
+      type: object
+      properties:
+        destination:
+          type: string
+          description: Destination CIDR.
+        status:
+          type: string
+          description: Route status.
+        target:
+          type: string
+          description: Route target (transit gateway id, VPN id, etc.).

--- a/spec/team_roles.yaml
+++ b/spec/team_roles.yaml
@@ -64,7 +64,7 @@ paths:
           $ref: '#/components/responses/BadRequestError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-        '201':    # status code
+        '200':
           $ref: '#/components/responses/SuccessListTeamRoles'
     post:
       operationId: assignTeamRoles
@@ -77,7 +77,7 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        '201':    # status code
+        '201':
           $ref: '#/components/responses/SuccessPostTeamRoles'
     delete:
       operationId: deleteTeamRoles


### PR DESCRIPTION
## Summary

Promotes 3 PRs already merged to `dev` up to `master`. On merge, the CI pipeline regenerates the affected client modules and pushes them to `github.com/mulesoft-anypoint/anypoint-client-go`.

- #71 `chore(agents): add AGENTS.md, CLAUDE.md, PR template`
- #72 `feat(private-space): add transit gateway endpoints + schemas (#74)`
- #73 `fix(team-roles): correct GET response status code 201 -> 200`

## Affected modules

- `anypoint-client-go/private_space` — new TGW CRUD endpoints, mulesoft-account + routes data sources, supporting schemas.
- `anypoint-client-go/team_roles` — bug fix in `GetTeamRoles` response code (`201` → `200`).

`chore/agents` does not touch any spec — no module regenerates for it.

## Related

- Downstream provider issue: `terraform-provider-anypoint#74` (AWS Transit Gateway support for private spaces).
- The provider feature branch is on hold for `private_space/vX.Y.Z` tag after this merge + CI publish.

## Type of change

- [x] New endpoint(s) on existing service (private_space)
- [x] Bug fix in existing schema / response (team_roles)
- [x] Generator config / tooling (agent rules + PR template)

## Spec checklist (cumulative)

- [x] OAS 3.0.0 across both spec files.
- [x] All new schemas under `#/components/schemas` with camelCase `title`.
- [x] No `oneOf` / `anyOf` introduced.
- [x] All new operations have stable `operationId`.
- [x] Raw-string body (`/privatespaces/{psId}/accounts`) declared as `schema: { type: string }`.
- [x] Standard error responses reference shared components.
- [x] `npx openapi-generator-cli validate -i spec/private_space.yml` clean.
- [x] `npx openapi-generator-cli validate -i spec/team_roles.yaml` clean.

## Local generation

- [x] `make generate` succeeded on `feature/private-space-tgw`.
- [x] Downstream provider built + ran end-to-end against the locally regenerated `private_space` module: create → update routes → update name → destroy all green. Live API state, Terraform state, and PS route table all consistent.

## Breaking change notice

None expected.

- `private_space`: purely additive (new paths + new schemas). Existing operations untouched.
- `team_roles`: response key `201 → 200` on `GetTeamRoles`. The previous spec was incorrect — the API returns 200, so generated clients that worked were doing so via the unknown-status fallback. Any consumer that explicitly checked `httpResp.StatusCode == 201` for the list endpoint was already broken against the real API.

## Release plan

After merge + CI publish, please tag:

- `private_space/v<MINOR+1>.0` — additive, minor bump from current.
- `team_roles/v<PATCH+1>` — fix-only, patch bump.

The downstream provider PR is gated on the `private_space` tag. Will switch from `go mod replace` to `go get @vX.Y.Z` once tagged.

## Notes for reviewer

- HAR evidence for the TGW endpoints lives in `recordings/cloudhub2/create-transit-gateway-attempt{3,4,5}.har` (sibling repo).
- The PATCH-routes endpoint has replace (not delta) semantics — confirmed via HAR + live API + Terraform end-to-end.
- The agent rules + PR template apply going forward; the chore PR itself predates the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)