### PR TITLE
fix(exchange_assets): remove asset from required fields

### DIFF
--- a/spec/exchange_assets.yml
+++ b/spec/exchange_assets.yml
@@ -685,7 +685,6 @@ components:
         - name
         - classifier
         - groupId
-        - asset
       type: object
       title: postAssetObject
       properties:


### PR DESCRIPTION
## Summary

- Drop `asset` from `postAssetObject.required` in `spec/exchange_assets.yml`. The field's own description already notes it is only required for `raml`, `raml-fragment`, `oas` and `wsdl` classifiers; declaring it universally required forced every generated client to reject `http`, `custom` and `mule-application` flows that pass an `assetLink` instead of an uploaded file.

## Affected modules

- `spec/exchange_assets.yml` → `anypoint-client-go/exchange_assets`

## Related

- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#58 (new resource `anypoint_exchange_asset`)

## Type of change

- [x] Bug fix in existing schema / response

## Spec checklist (OAS3 conventions)

- [x] OAS 3.0.0.
- [x] All schemas live in `#/components/schemas`; paths reference via `$ref`.
- [x] Every schema and every attribute has a `title`.
- [x] No `oneOf` / `anyOf` in response bodies.
- [x] Validated locally via `openapi-generator-cli validate -i spec/exchange_assets.yml`.
- [x] Regenerated locally via `make generate` and consumed from the provider.

## Notes

This unblocks the upcoming `anypoint_exchange_asset` resource in `terraform-provider-anypoint` (v1.10.0). A separate follow-up will address the unrelated `file` schema name collision in the same spec (the generator types `Asset.Files` as `[]*os.File` because the schema is named `file`).