### PR TITLE
release: exchange_assets asset-required fix to master

### DIFF
--- a/spec/exchange_assets.yml
+++ b/spec/exchange_assets.yml
@@ -685,7 +685,6 @@ components:
         - name
         - classifier
         - groupId
-        - asset
       type: object
       title: postAssetObject
       properties:


### PR DESCRIPTION
## Summary

- Promote `dev` to `master` to publish the `exchange_assets` spec fix (PR #79: dropped `asset` from `postAssetObject.required`).
- Master-merge triggers the CI pipeline that regenerates and publishes `anypoint-client-go/exchange_assets`.

## Affected modules

- `spec/exchange_assets.yml` → `anypoint-client-go/exchange_assets`

## Related

- Source PR: #79
- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#58

## Post-merge

- Tag `exchange_assets/v0.0.4` on `anypoint-client-go` once the generated module lands.
- Provider PR (terraform-provider-anypoint) will drop the local `replace` directive and `go get @v0.0.4`.