### PR TITLE
feat(connected_app): owner_user_id on PATCH for ownership transfer

### DIFF
--- a/spec/connected_app.yml
+++ b/spec/connected_app.yml
@@ -407,6 +407,11 @@ components:
               type: boolean
               title: enabled
               example: true
+            owner_user_id:
+              type: string
+              title: ownerUserId
+              description: User id of the connected app owner. Set to transfer ownership.
+              example: "9exb9686-4e35-81e0-45ac-8c83662480c0"
 
     scopeCore:
       title: scopeCore


### PR DESCRIPTION
## Summary

- Adds `owner_user_id` to `connectedAppPatchExt` so the connected-app PATCH endpoint accepts an ownership transfer in the same payload.

## Affected modules

- `spec/connected_app.yml` → `anypoint-client-go/connected_app`

## Related

- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#52
- HAR evidence: `recordings/access_management/update-connected-app-owner.har` (in `Anypoint-Devops-Collective/`)

The HAR shows the UI's Owners-tab change sending a single PATCH on `/accounts/api/organizations/{orgId}/connectedApplications/{clientId}` with `owner_user_id` in the body — no separate sub-resource endpoint.

## Type of change

- [x] New endpoint(s) on existing service (new field on existing PATCH body)
- [ ] New service (whole new spec file)
- [ ] Bug fix in existing schema / response
- [ ] Breaking change (renamed field, removed endpoint, changed required-ness)
- [ ] Generator config / tooling

## Spec checklist (OAS3 conventions)

- [x] OAS 3.0.0.
- [x] All schemas live in `#/components/schemas`.
- [x] Every schema and every attribute has a `title`.
- [x] No `oneOf` / `anyOf`.
- [x] `operationId` unchanged.
- [x] Standard error responses unchanged.
- [x] Field is `optional` on the PATCH body (not required).
- [x] `npx openapi-generator-cli validate -i spec/connected_app.yml` clean.

## Local generation

- [x] `make generate` succeeds, no warnings.
- [x] Local consumer test: provider switched via `go mod edit -replace`, `go build ./...` clean.
- [x] End-to-end playground: create → transfer owner → reverse transfer → drift-free plan → destroy. All clean.

## Release plan

- [x] On merge to `master`, pipeline regenerates `anypoint-client-go/connected_app`.
- [ ] After pipeline publishes, tag `connected_app/v1.2.0` (minor bump: additive field, no breaking change).
- [ ] Provider switches from `replace` → released tag once the tag is up.

## Notes for reviewer

The provider PR is staged locally (DefaultAPI rename + schema flip from Computed → Optional+Computed on `user_id` + wire `SetOwnerUserId` in PATCH body). It will be opened once the client module is tagged.