### PR TITLE
Release: connected_app owner_user_id on PATCH

### DIFF
--- a/spec/connected_app.yml
+++ b/spec/connected_app.yml
@@ -407,6 +407,11 @@ components:
               type: boolean
               title: enabled
               example: true
+            owner_user_id:
+              type: string
+              title: ownerUserId
+              description: User id of the connected app owner. Set to transfer ownership.
+              example: "9exb9686-4e35-81e0-45ac-8c83662480c0"
 
     scopeCore:
       title: scopeCore


### PR DESCRIPTION
## Summary

Promote `dev` → `master` to trigger client regeneration for `connected_app`.

- mulesoft-anypoint/anypoint-automation-client-generator#81 — `feat(connected_app): add owner_user_id to PATCH body for ownership transfer`

## Affected modules

- `spec/connected_app.yml` → `anypoint-client-go/connected_app`

## Related

- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#52

## Release plan

- On merge to `master`, pipeline regenerates `anypoint-client-go/connected_app`.
- After publish, tag `connected_app/v1.2.0` (minor: additive PATCH field, non-breaking).
- Provider PR (`feature/connected-app-owner`) is staged locally; will switch from `replace` → released tag and open against `dev` once the tag is up.