### PR TITLE
feat(apim_policy): add outbound policy CRUD endpoints

### DIFF
--- a/spec/apim_policy.yml
+++ b/spec/apim_policy.yml
@@ -415,6 +415,204 @@ paths:
         '201':    # status code
           $ref: '#/components/responses/SuccessEnableApimPolicy'
 
+  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies:
+    parameters:
+      - in: path
+        name: orgId
+        description: The organization Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: envId
+        description: The environment Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiId
+        description: The api manager instance Id
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: GetApimOutboundPolicies
+      summary: Retrieve all of api manager instance outbound policies.
+      description: Retrieve all of api manager instance outbound policies in a given organization and environment.
+      parameters:
+        - in: query
+          name: fullInfo
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':    # status code
+          $ref: '#/components/responses/SuccessGetApimOutboundPolicies'
+    post:
+      operationId: PostApimOutboundPolicy
+      summary: Create an api manager instance outbound policy.
+      description: Create an api manager instance outbound policy in a given organization and environment.
+      requestBody:
+        description: outbound policy content
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApimPolicyBody"
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '201':    # status code
+          $ref: '#/components/responses/SuccessPostApimOutboundPolicy'
+
+  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}:
+    parameters:
+      - in: path
+        name: orgId
+        description: The organization Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: envId
+        description: The environment Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiId
+        description: The api manager instance Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiPolicyId
+        description: The api manager instance outbound policy Id
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: GetApimOutboundPolicy
+      summary: Retrieve a specific api manager instance outbound policy.
+      description: Retrieve a specific api manager instance outbound policy in a given organization and environment.
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':    # status code
+          $ref: '#/components/responses/SuccessGetApimOutboundPolicy'
+    patch:
+      operationId: PatchApimOutboundPolicy
+      summary: Update a specific api manager instance outbound policy.
+      description: Update a specific api manager instance outbound policy in a given organization and environment.
+      requestBody:
+        description: outbound policy content
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApimPolicyPatchBody"
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '200':    # status code
+          $ref: '#/components/responses/SuccessPatchApimOutboundPolicy'
+    delete:
+      operationId: DeleteApimOutboundPolicy
+      summary: Delete a specific api manager instance outbound policy.
+      description: Delete a specific api manager instance outbound policy in a given organization and environment.
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '204':    # status code
+          $ref: '#/components/responses/SuccessDeleteApimOutboundPolicy'
+
+  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable:
+    parameters:
+      - in: path
+        name: orgId
+        description: The organization Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: envId
+        description: The environment Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiId
+        description: The api manager instance Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiPolicyId
+        description: The api manager instance outbound policy Id
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: DisableApimOutboundPolicy
+      summary: Disable a specific api manager instance outbound policy.
+      description: Disable a specific api manager instance outbound policy in a given organization and environment.
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '201':    # status code
+          $ref: '#/components/responses/SuccessDisableApimOutboundPolicy'
+
+  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable:
+    parameters:
+      - in: path
+        name: orgId
+        description: The organization Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: envId
+        description: The environment Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiId
+        description: The api manager instance Id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: apiPolicyId
+        description: The api manager instance outbound policy Id
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: EnableApimOutboundPolicy
+      summary: Enable a specific api manager instance outbound policy.
+      description: Enable a specific api manager instance outbound policy in a given organization and environment.
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '201':    # status code
+          $ref: '#/components/responses/SuccessEnableApimOutboundPolicy'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -497,6 +695,44 @@ components:
             $ref: "#/components/schemas/ApimPolicy"
     SuccessEnableApimPolicy:
       description: enable specific api manager policy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicy"
+    SuccessGetApimOutboundPolicies:
+      description: list api manager outbound policies
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicyCollection"
+    SuccessPostApimOutboundPolicy:
+      description: create api manager outbound policy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicy"
+    SuccessGetApimOutboundPolicy:
+      description: get specific api manager outbound policy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicy"
+    SuccessPatchApimOutboundPolicy:
+      description: patch specific api manager outbound policy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicy"
+    SuccessDeleteApimOutboundPolicy:
+      description: delete specific api manager outbound policy
+    SuccessDisableApimOutboundPolicy:
+      description: disable specific api manager outbound policy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApimPolicy"
+    SuccessEnableApimOutboundPolicy:
+      description: enable specific api manager outbound policy
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Summary

- Adds outbound policy CRUD endpoints to `spec/apim_policy.yml` (POST/GET-list/GET/PATCH/DELETE/enable/disable) under `/apis/{apiId}/policies/outbound-policies`.
- Request/response bodies are byte-identical to the existing inbound family — reuses `ApimPolicyBody`, `ApimPolicyPatchBody`, `ApimPolicy`, `ApimPolicyCollection` schemas. Only the URL path changes.
- Unblocks outbound-only policy templates (credential-injection-oauth2-obo, credential-injection-basic-auth-flex, and the LLM-provider/transcoding policies that anchor the v1.11 AI strand on the provider side).

## Affected modules

- `spec/apim_policy.yml` → `anypoint-client-go/apim_policy`

Proposed version: **`apim_policy/v0.3.0`** (v0.2.0 was the split-asset / injection_point filter pass on exchange-policy-templates; v0.3.0 adds the outbound CRUD family).

## Related

- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#139
- Provider PR: to follow once this branch is generated and the client module is tagged. Will reference back here.
- Anypoint API docs: outbound policy endpoints are not documented publicly; surface confirmed via the issue reporter's working `null_resource` + `local-exec curl` workaround that hit `.../apis/{apiId}/policies/outbound-policies` directly.

## Type of change

- [x] New endpoint(s) on existing service

## Spec checklist (OAS3 conventions)

- [x] OAS 3.0.0.
- [x] All schemas live in `#/components/schemas`; paths reference via `$ref`.
- [x] Every schema and every attribute has a `title` (no new schemas added — reuses existing inbound family).
- [x] No `oneOf` / `anyOf` in response bodies.
- [x] `operationId` set on every operation, verb-prefixed, stable (`PostApimOutboundPolicy`, `GetApimOutboundPolicies`, `GetApimOutboundPolicy`, `PatchApimOutboundPolicy`, `DeleteApimOutboundPolicy`, `EnableApimOutboundPolicy`, `DisableApimOutboundPolicy`).
- [x] Standard error responses (`401`, `404`) `$ref` shared components.
- [x] No unnecessary `required` fields.
- [x] `npx openapi-generator-cli validate -i spec/apim_policy.yml` clean (only pre-existing warnings: unused `ErrorsResponse` + `PolicyConfiguration` models).

## Local generation

- [x] `make generate` succeeds.
- [ ] Local consumer test (`go mod edit -replace ...=./dest/apim_policy` in `terraform-provider-anypoint`): in progress — provider PR will be opened referencing this branch.
