### PR TITLE
fix(apim_policy): rework outbound policy spec against real API

### DIFF
--- a/spec/apim_policy.yml
+++ b/spec/apim_policy.yml
@@ -415,7 +415,7 @@ paths:
         '201':    # status code
           $ref: '#/components/responses/SuccessEnableApimPolicy'
 
-  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies:
+  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies:
     parameters:
       - in: path
         name: orgId
@@ -435,34 +435,22 @@ paths:
         required: true
         schema:
           type: string
-    get:
-      operationId: GetApimOutboundPolicies
-      summary: Retrieve all of api manager instance outbound policies.
-      description: Retrieve all of api manager instance outbound policies in a given organization and environment.
-      parameters:
-        - in: query
-          name: fullInfo
-          required: false
-          schema:
-            type: boolean
-            default: false
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '200':    # status code
-          $ref: '#/components/responses/SuccessGetApimOutboundPolicies'
     post:
       operationId: PostApimOutboundPolicy
       summary: Create an api manager instance outbound policy.
-      description: Create an api manager instance outbound policy in a given organization and environment.
+      description: >
+        Create an api manager instance outbound policy in a given organization and environment.
+        The request body must include `upstreamIds` (one or more existing upstream ids).
+        The API creates one policy record per upstream id and returns the array of created
+        policy records. Read/Update/Delete/Enable/Disable use the singular policy endpoints
+        (`PatchApimPolicy` / `DeleteApimPolicy` / `EnableApimPolicy` / `DisableApimPolicy`)
+        with the integer `id` returned here.
       requestBody:
         description: outbound policy content
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApimPolicyBody"
+              $ref: "#/components/schemas/ApimOutboundPolicyBody"
       responses:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
@@ -470,148 +458,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
         '201':    # status code
           $ref: '#/components/responses/SuccessPostApimOutboundPolicy'
-
-  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}:
-    parameters:
-      - in: path
-        name: orgId
-        description: The organization Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: envId
-        description: The environment Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiId
-        description: The api manager instance Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiPolicyId
-        description: The api manager instance outbound policy Id
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: GetApimOutboundPolicy
-      summary: Retrieve a specific api manager instance outbound policy.
-      description: Retrieve a specific api manager instance outbound policy in a given organization and environment.
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '200':    # status code
-          $ref: '#/components/responses/SuccessGetApimOutboundPolicy'
-    patch:
-      operationId: PatchApimOutboundPolicy
-      summary: Update a specific api manager instance outbound policy.
-      description: Update a specific api manager instance outbound policy in a given organization and environment.
-      requestBody:
-        description: outbound policy content
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ApimPolicyPatchBody"
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '200':    # status code
-          $ref: '#/components/responses/SuccessPatchApimOutboundPolicy'
-    delete:
-      operationId: DeleteApimOutboundPolicy
-      summary: Delete a specific api manager instance outbound policy.
-      description: Delete a specific api manager instance outbound policy in a given organization and environment.
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '204':    # status code
-          $ref: '#/components/responses/SuccessDeleteApimOutboundPolicy'
-
-  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable:
-    parameters:
-      - in: path
-        name: orgId
-        description: The organization Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: envId
-        description: The environment Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiId
-        description: The api manager instance Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiPolicyId
-        description: The api manager instance outbound policy Id
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: DisableApimOutboundPolicy
-      summary: Disable a specific api manager instance outbound policy.
-      description: Disable a specific api manager instance outbound policy in a given organization and environment.
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '201':    # status code
-          $ref: '#/components/responses/SuccessDisableApimOutboundPolicy'
-
-  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable:
-    parameters:
-      - in: path
-        name: orgId
-        description: The organization Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: envId
-        description: The environment Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiId
-        description: The api manager instance Id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: apiPolicyId
-        description: The api manager instance outbound policy Id
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: EnableApimOutboundPolicy
-      summary: Enable a specific api manager instance outbound policy.
-      description: Enable a specific api manager instance outbound policy in a given organization and environment.
-      responses:
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
-        '201':    # status code
-          $ref: '#/components/responses/SuccessEnableApimOutboundPolicy'
 
 components:
   securitySchemes:
@@ -699,44 +545,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ApimPolicy"
-    SuccessGetApimOutboundPolicies:
-      description: list api manager outbound policies
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ApimPolicyCollection"
     SuccessPostApimOutboundPolicy:
-      description: create api manager outbound policy
+      description: >
+        create api manager outbound policy — returns an array of policy records,
+        one per upstream id in the request body.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ApimPolicy"
-    SuccessGetApimOutboundPolicy:
-      description: get specific api manager outbound policy
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ApimPolicy"
-    SuccessPatchApimOutboundPolicy:
-      description: patch specific api manager outbound policy
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ApimPolicy"
-    SuccessDeleteApimOutboundPolicy:
-      description: delete specific api manager outbound policy
-    SuccessDisableApimOutboundPolicy:
-      description: disable specific api manager outbound policy
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ApimPolicy"
-    SuccessEnableApimOutboundPolicy:
-      description: enable specific api manager outbound policy
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ApimPolicy"
+            $ref: "#/components/schemas/ApimOutboundPolicyCollection"
 
   schemas:
     ErrorsResponse:
@@ -1014,6 +830,17 @@ components:
           type: string
         apiId:
           type: integer
+        label:
+          type: string
+          nullable: true
+          description: Optional label applied to this policy instance.
+        upstreamId:
+          type: string
+          nullable: true
+          description: >
+            Identifier of the upstream this policy is bound to. Populated only when
+            the policy was created via the outbound endpoint (`PostApimOutboundPolicy`).
+            Absent for inbound policies.
 
     ApimPolicyFull:
       type: object
@@ -1057,6 +884,50 @@ components:
           type: integer
         pointcutData:
           $ref: "#/components/schemas/PointcutData"
+
+    ApimOutboundPolicyBody:
+      type: object
+      description: >
+        Request body for creating an outbound policy. Differs from `ApimPolicyBody` in
+        two ways: it carries `apiVersionId` + `upstreamIds` (required, one or more
+        upstream identifiers), and it does NOT carry `pointcutData` — outbound policies
+        apply at the upstream binding level rather than via URL pointcuts.
+      required:
+        - configurationData
+        - apiVersionId
+        - groupId
+        - assetId
+        - assetVersion
+        - upstreamIds
+      properties:
+        configurationData:
+          type: object
+        apiVersionId:
+          type: integer
+          description: The numeric API instance id (same as `apiId` in `ApimPolicy`).
+        groupId:
+          type: string
+        assetId:
+          type: string
+        assetVersion:
+          type: string
+        label:
+          type: string
+          nullable: true
+        upstreamIds:
+          type: array
+          description: >
+            Upstream identifiers (UUID strings) the policy must bind to. The API
+            creates one policy record per id and returns them all in the response array.
+          items:
+            type: string
+
+    ApimOutboundPolicyCollection:
+      type: array
+      title: "ApimOutboundPolicyCollection"
+      description: One policy record per upstream id in the create request body.
+      items:
+        $ref: "#/components/schemas/ApimPolicy"
 
     ApimPolicyPatchBody:
       type: object


### PR DESCRIPTION
## Summary

- Re-author the outbound policy family in `spec/apim_policy.yml` against the real API shape captured during issue #139 playground verification.
- Drop the six outbound-specific endpoints introduced by v0.3.0 — read / update / delete / enable / disable on outbound rows reuse the existing inbound singular endpoints, verified with the same integer policy id returned from the outbound POST.
- Add `upstreamId` + `label` to the `ApimPolicy` response schema (both nullable).

## Affected modules

- `spec/apim_policy.yml` →  `anypoint-client-go/apim_policy` — next tag `v0.4.0`.

## Related

- Provider issue: https://github.com/mulesoft-anypoint/terraform-provider-anypoint/issues/139 — `anypoint_apim_policy_custom` outbound endpoints unreachable.
- Provider tracker: https://github.com/mulesoft-anypoint/terraform-provider-anypoint/issues/142 — defects this PR repairs.
- Provider PR: https://github.com/mulesoft-anypoint/terraform-provider-anypoint/pull/141 (draft) — rebases on this once `v0.4.0` is tagged.
- API surface captured via direct OAuth-token probe against `aa1f55d6-213d-4f60-845c-207286484cd1` / env `7074fcdd-9b23-4ab3-97c8-5db5f4adf17d` on the US control plane (2026-06-01).

## What v0.3.0 got wrong

| Item | v0.3.0 | Real API |
|---|---|---|
| Base path | `/api/v1/.../policies/outbound-policies` | `/xapi/v1/.../policies/outbound-policies` |
| `upstreamIds` body field | absent (reused `ApimPolicyBody`) | required, array of UUID strings |
| `pointcutData` body field | nullable, present | rejected — must be omitted entirely |
| Outbound GET / PATCH / DELETE / enable / disable | defined as separate routes | do not exist — outbound rows are served by the inbound singular endpoints |

## What this PR does

- Move `POST .../outbound-policies` from `/api/v1/` to `/xapi/v1/`. Sole outbound-specific operation that remains.
- Introduce `ApimOutboundPolicyBody` — required fields `configurationData`, `apiVersionId`, `groupId`, `assetId`, `assetVersion`, `upstreamIds`. Optional nullable `label`. No `pointcutData`.
- `PostApimOutboundPolicy` response type changes from `ApimPolicy` (single) to `[]ApimPolicy` (one record per upstream id, as the API returns).
- Remove `GetApimOutboundPolicies`, `GetApimOutboundPolicy`, `PatchApimOutboundPolicy`, `DeleteApimOutboundPolicy`, `EnableApimOutboundPolicy`, `DisableApimOutboundPolicy` and their response definitions. Consumers use the inbound `GetApimPolicy` / `PatchApimPolicy` / `DeleteApimPolicy` / `EnableApimPolicy` / `DisableApimPolicy` instead — the same integer policy id works for both inbound and outbound rows.
- Extend `ApimPolicy` with `upstreamId` (nullable string, populated only on outbound rows) and `label` (nullable string).

## Type of change

- [x] Bug fix in existing schema / response
- [x] Breaking change (removed six operations, restructured POST request/response)
- [ ] New endpoint(s) on existing service
- [ ] New service
- [ ] Generator config / tooling

The breaking change is contained — `apim_policy/v0.3.0` is non-functional on outbound (issue #142), so no real consumer is affected.

## Spec checklist

- [x] OAS 3.0.0.
- [x] Validates clean (`npx openapi-generator-cli validate -i spec/apim_policy.yml`). Two pre-existing unused-model warnings remain.
- [x] All new schemas live in `#/components/schemas` with `title` set where applicable.
- [x] No `oneOf` / `anyOf` introduced.
- [x] `operationId` set, verb-prefixed, stable.

## Verification

Regenerated the module locally, switched the provider to it via `go mod replace`, and ran a full Terraform CRUD cycle against the real API in the playground:

| Op | Endpoint | Result |
|---|---|---|
| Create | POST `/xapi/v1/.../outbound-policies` | 201, policy id returned, `upstreamId` populated on the response object |
| Read | GET `/api/v1/.../policies/{id}` | `upstreamId` surfaced in Terraform state |
| Update | PATCH `/api/v1/.../policies/{id}` | scope change confirmed via raw curl |
| Destroy | DELETE `/api/v1/.../policies/{id}` | 204, instance + policy gone from the API |

The provider-side wiring goes up in PR #141 once `apim_policy/v0.4.0` is tagged.