### PR TITLE
feat(exchange_assets): add PostLLMAsset for type=llm publishing

### DIFF
--- a/spec/exchange_assets.yml
+++ b/spec/exchange_assets.yml
@@ -212,6 +212,61 @@ paths:
         '204':
           $ref: '#/components/responses/SuccessPatchAsset'
 
+  /organizations/{orgId}/assets/{groupId}/{assetId}/{version}:
+    post:
+      summary: Publish an LLM-typed Exchange asset
+      description: |-
+        Publish an Exchange asset of type "llm". This is the metadata-only variant
+        used by the Anypoint AI Gateway: no spec file is uploaded — Anypoint
+        generates the LLM metadata artifacts server-side. Returns 202 with the
+        publication status link; the resource is queryable immediately
+        (Exchange publish is synchronous from the caller's perspective).
+      operationId: PostLLMAsset
+      parameters:
+        - name: orgId
+          in: path
+          description: The ID of the organization in GUID format
+          required: true
+          schema:
+            type: string
+        - name: groupId
+          in: path
+          description: The business group id (often equals orgId for root-level assets)
+          required: true
+          schema:
+            type: string
+        - name: assetId
+          in: path
+          description: The asset slug
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: The asset version (must follow Semver, e.g. 1.0.0)
+          required: true
+          schema:
+            type: string
+        - name: x-strict-package
+          in: header
+          description: Indicates if the asset package is immutable.
+          required: false
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/postLLMAssetObject'
+      responses:
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '202':
+          $ref: '#/components/responses/SuccessPostLLMAsset'
+
   /assets/{orgId}/{assetId}/{version}:
     delete:
       summary: Delete an asset
@@ -298,6 +353,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/postAssetResponse'
+    SuccessPostLLMAsset:
+      description: LLM asset publication accepted
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/postLLMAssetResponse'
     SuccessGetAsset:
       description: Success response
       content:
@@ -807,3 +868,68 @@ components:
         type:
           type: string
           title: type
+
+    postLLMAssetObject:
+      required:
+        - name
+        - type
+        - status
+      type: object
+      title: postLLMAssetObject
+      description: |-
+        Multipart body for publishing an LLM-typed Exchange asset.
+
+        Field naming note: Anypoint requires the literal dotted multipart key
+        `properties.platform`. The underscored variant `properties_platform`
+        is silently accepted by the POST endpoint (returns 202) but produces
+        a ghost asset that is not retrievable. The schema property name uses
+        the dotted form to ensure the openapi-generator multipart serializer
+        emits the correct field name on the wire. The generated Go identifier
+        is renamed to `PropertiesPlatform` by the generator.
+      properties:
+        name:
+          type: string
+          title: name
+          description: The visible name of the asset.
+        type:
+          type: string
+          enum:
+            - llm
+          title: type
+          description: Always "llm" for this resource.
+        status:
+          type: string
+          enum:
+            - published
+            - draft
+          default: published
+          title: status
+          description: Publication status. Defaults to "published".
+        properties.platform:
+          type: string
+          title: properties.platform
+          description: |-
+            The LLM vendor identifier. Free string — Anypoint does not enforce
+            an enum. Known values include "openai", "bedrock", "anthropic",
+            "azure-openai", "gemini", "other". Defaults server-side to "other"
+            if omitted.
+        tags:
+          type: string
+          title: tags
+          description: |-
+            Stringified JSON array of asset tags. Optional. The field must be
+            sent as a String; pass the stringified value.
+
+    postLLMAssetResponse:
+      type: object
+      title: postLLMAssetResponse
+      description: Acknowledgement of the LLM asset publication.
+      properties:
+        publicationStatusLink:
+          type: string
+          title: publicationStatusLink
+          description: |-
+            URL pointing to the publication status of the newly created asset.
+            Exchange publish is synchronous from the caller's perspective; the
+            asset is queryable immediately. This link is the resource location,
+            not an async completion handle.


### PR DESCRIPTION
## Summary

- Adds `POST /organizations/{orgId}/assets/{groupId}/{assetId}/{version}` for publishing Exchange assets of type `llm`.
- Metadata-only — no spec file upload. Anypoint generates the LLM metadata artifacts server-side.
- Multipart fields: `name`, `type=llm`, `status`, optional `properties.platform`, optional `tags`.

## Affected modules

- `spec/exchange_assets.yml` → `anypoint-client-go/exchange_assets`

## Related

- Provider PR: mulesoft-anypoint/terraform-provider-anypoint#150 — `anypoint_ai_gateway` composite needs an LLM-typed Exchange asset to satisfy the `llm-proxy-core` policy gate (`assetTypes: ["llm"]`).
- HAR: `recordings/exchange/create-exchaqnde-assets.har` (in `Anypoint-Devops-Collective/`).

The HAR shows the new asset types (`llm`, `agent`, `mcp`, `grpc-api`, `graphql`, `soap-api`, `policy`) using a `type` field instead of legacy `classifier`. This PR covers `llm` only — agent / mcp / etc. will follow in separate PRs.

## Notes

- Multipart field MUST be `type`. Probe confirmed `classifier=llm` silently 202s but produces a ghost asset.
- `properties.platform` is optional; server defaults to `other`. No server-side enum.
- Legacy `POST /assets` is left untouched.

## Type of change

- [x] New endpoint(s) on existing service
- [ ] New service (whole new spec file)
- [ ] Bug fix in existing schema / response
- [ ] Breaking change
- [ ] Generator config / tooling