### PR TITLE
fix(private_space): drop reservedCidrs from PrivateSpaceNetworkEditable

### DIFF
--- a/spec/private_space.yml
+++ b/spec/private_space.yml
@@ -1034,17 +1034,6 @@ components:
               items:
                 type: string
                 description: The special domain of the VPC.
-        reservedCidrs:
-          type: array
-          description: >
-            The list of reserved CIDR blocks for your private space to prevent IP address overlap.
-            Required when you want to connect your private space to your corporate network (either on-premises or in the cloud).
-            Use CIDR notation and commas.
-          example: ["192.168.0.0/16", "172.16.0.0/12"]
-          items:
-            type: string
-            description: The reserved CIDR of the Private Space network.
-
     PrivateSpaceNetwork:
       type: object
       description: Private space network configuration


### PR DESCRIPTION
## Summary

- Remove `reservedCidrs` from `PrivateSpaceNetworkEditable`. Reserved CIDRs are immutable once the network is created (the Anypoint API returns `HTTP 400 "Reserved CIDR's cannot be updated once the network is created"`), so they must not appear on the PATCH model. They remain on `PrivateSpaceNetworkCreate` and the read model `PrivateSpaceNetwork`.

## Affected modules

- `spec/private_space.yml` → `anypoint-client-go/private_space`

## Related

- Provider fix: mulesoft-anypoint/terraform-provider-anypoint#163 (already merged — provider stopped sending the field on update and marked it `ForceNew`).
- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#162

## Type of change

- [x] Bug fix in existing schema / response
- [x] Breaking change (removed field from `PrivateSpaceNetworkEditable`)

## Spec checklist (OAS3 conventions)

- [x] `npx openapi-generator-cli validate -i spec/private_space.yml` is clean.
- [x] Change limited to removing one invalid property; no new schemas/operations.

## Breaking change notice

Removes `Get/SetReservedCidrs` from the generated `PrivateSpaceNetworkEditable` type. The only known consumer (the provider) no longer references it as of #163, so no migration is required there.

## Release plan

- [ ] On merge to `master`, pipeline regenerates `anypoint-client-go/private_space`.
- [ ] Tag the module. Proposed: `private_space/v1.4.0` (removes an invalid field; downstream provider already updated). Bump to `v2.0.0` instead if strict semver for the removed method is preferred.
